### PR TITLE
Fixes three main issues which made running netNMF-sc not possible

### DIFF
--- a/netNMFsc/run_netNMF-sc.py
+++ b/netNMFsc/run_netNMF-sc.py
@@ -16,8 +16,8 @@ def main(args):
         from .classes import netNMFGD
         operator = netNMFGD(d=args.dimensions, alpha=args.alpha, n_inits=1, tol=args.tol, max_iter=args.max_iters, n_jobs=1)
     elif args.method == 'MU':
-        from .classes import netNMFMU   
-        operator = netNMFMU(d=args.dimensions, alpha=args.alpha, n_inits=1, tol=args.tol, max_iter=args.max_iters, n_jobs=1)
+        from .classes import netNMFMU
+        operator = netNMFMU(n_components=args.dimensions, alpha=args.alpha, tol=args.tol, max_iter=args.max_iters)
     operator.load_10X(direc=args.tenXdir,genome='mm10')
     operator.load_network(net=args.network,genenames=args.netgenes,sparsity=args.sparsity)
     W, H = operator.fit_transform()


### PR DESCRIPTION
When I tried running netNMF-sc from the command line on some of my data I ran
into the following bugs:  

    1. Minor issues in run_netNMF-sc.py related to wrong keyword arguments
        being passed to the netNMFMU class.
    2. Minor issues in the class netNMFGD from classes.py. Every 
        issue was a tensorflow 2.0 incompatibility.
    3. Refactored the class netNMFMU to follow the api establised in
        netNMFGD, specifically you don't have to pass your data in the
        fit_transform method. This required copying a couple of methods
        from netNMFGD to netNMFMU, and adding some attributes.

This commit fixes these issues. 